### PR TITLE
Update multi-point-vpn API schema & remove README

### DIFF
--- a/code/API_definitions/README.MD
+++ b/code/API_definitions/README.MD
@@ -1,1 +1,0 @@
-Here you can add your definition file(s). Delete this README.MD file after the first file is added.

--- a/code/API_definitions/multi-point-vpn.yaml
+++ b/code/API_definitions/multi-point-vpn.yaml
@@ -530,7 +530,7 @@ components:
               type: site
               primaryIP: 84.125.93.10
               secondaryIP: 84.125.94.10
-        resourceGroupId: 12121
+        resourceGroupId: '12121'
         cloudGatewayIP: 1.2.3.4
     siteToCloudVPNUpdateConnectionRequest:
       summary: Update Connection Sample 1

--- a/code/API_definitions/multi-point-vpn.yaml
+++ b/code/API_definitions/multi-point-vpn.yaml
@@ -71,7 +71,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Connection"
+                $ref: "#/components/schemas/Network"
               examples:
                 SITE_TO_CLOUD_VPN_CREATE_CONNECTION_RESPONSE:
                   $ref: "#/components/examples/siteToCloudVPNCreateConnectionResponse"
@@ -111,7 +111,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Connection"
+                $ref: "#/components/schemas/Network"
               examples:
                 SITE_TO_CLOUD_VPN_CREATE_CONNECTION_RESPONSE:
                   $ref: "#/components/examples/siteToCloudVPNCreateConnectionResponse"
@@ -128,7 +128,7 @@ paths:
         - Network
       summary: retrieve multipoint virtual private network details
       description: Retrieve multipoint virtual private network details
-      operationId: getVPNConnect
+      operationId: getVpnConnection
       parameters:
         - $ref: "#/components/parameters/x-correlator"
         - $ref: '#/components/parameters/serviceId'
@@ -141,7 +141,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Connection"
+                $ref: "#/components/schemas/Network"
               examples:
                 SITE_TO_CLOUD_VPN_CREATE_CONNECTION_RESPONSE:
                   $ref: "#/components/examples/siteToCloudVPNCreateConnectionResponse"
@@ -259,6 +259,7 @@ components:
           description: Is Multipoint VPN protected
         connections:
           type: array
+          description: list of connections details for customer and provider
           items:
             $ref: '#/components/schemas/Connection'
         guaranteeBandwidth:
@@ -269,6 +270,7 @@ components:
           $ref: '#/components/schemas/Duration'
     AssessmentResult:
       type: object
+      description: Assessment Result
       properties:
         waitdays:
           type: integer
@@ -276,6 +278,7 @@ components:
           minimum: 1
         sla:
           type: string
+          description: Service Level Agreement between customer and provider
           enum:
             - A
             - AA
@@ -283,6 +286,7 @@ components:
         rent:
           $ref: '#/components/schemas/Amount'
     Connection:
+      description: Base Connection Entity structure
       allOf:
         - type: object
           description: Another Characteristic that is related to the current Characteristic;
@@ -341,17 +345,22 @@ components:
           description: connection location
     IpAddress:
       type: object
+      description: Ip address details      
       properties:
         addressType:
           type: string
+          description: address type, Ipv4 or Ipv6
       required:
         - addressType
       discriminator:
         propertyName: addressType
-        mappings:
-          - Ipv4Addr: '#/components/schemas/Ipv4Address'
-          - Ipv6Addr: '#/components/schemas/Ipv6Address'
+        mapping:
+          Ipv4Addr: 
+            $ref: '#/components/schemas/Ipv4Address'
+          Ipv6Addr:
+            $ref: '#/components/schemas/Ipv6Address'
     Ipv4Address:
+      description: Ipv4 address details
       allOf:
         - $ref: '#/components/schemas/IpAddress'
         - type: object
@@ -362,6 +371,7 @@ components:
               type: string
               format: ipv4
     Ipv6Address:
+      description: Ipv6 address details
       allOf:
         - $ref: '#/components/schemas/IpAddress'
         - type: object
@@ -386,10 +396,12 @@ components:
           description: Is Multipoint VPN protected
         connections:
           type: array
+          description: list of connections details for customer and provider
           items:
             $ref: '#/components/schemas/Connection'
         sla:
           type: string
+          description: Service Level Agreement between customer and provider
           enum:
             - A
             - AA
@@ -402,10 +414,13 @@ components:
           $ref: '#/components/schemas/Duration'
         routeProtocal:
           type: string
+          description: Routing Protocol used for this network
         resourceGroupId:
           type: string
+          description: Resource Group Id
         cloudGatewayIP:
           type: string
+          description: Cloud Gateway IP
     NetworkCreate:
       description: Base Connection Entity structure
       type: object
@@ -418,6 +433,7 @@ components:
           description: Is Multipoint VPN protected
         connections:
           type: array
+          description: list of connections details for customer and provider
           items:
             $ref: '#/components/schemas/Connection'
         guaranteeBandwidth:
@@ -426,6 +442,7 @@ components:
           minimum: 1
         sla:
           type: string
+          description: Service Level Agreement between customer and provider
           enum:
             - A
             - AA
@@ -434,6 +451,7 @@ components:
           $ref: '#/components/schemas/Duration'
         routeProtocal:
           type: string
+          description: Routing Protocol used for this network
     NetworkUpdate:
       description: Base Connection Entity structure
       type: object
@@ -443,6 +461,7 @@ components:
           description: Guarantee Bandwidth (Mps)
         sla:
           type: string
+          description: Service Level Agreement between customer and provider
           enum:
             - A
             - AA

--- a/code/API_definitions/multi-point-vpn.yaml
+++ b/code/API_definitions/multi-point-vpn.yaml
@@ -367,6 +367,7 @@ components:
         address:
           type: string
           format: ipv4
+          description: ipv4 address
     Ipv6Address:
       type: object
       description: Ipv6 address details
@@ -380,6 +381,7 @@ components:
         address:
           type: string
           format: ipv6
+          description: ipv6 address
     Network:
       description: Base Network Entity structure
       type: object

--- a/code/API_definitions/multi-point-vpn.yaml
+++ b/code/API_definitions/multi-point-vpn.yaml
@@ -346,39 +346,40 @@ components:
     IpAddress:
       type: object
       description: Ip address details
-      properties:
-        addressType:
-          type: string
-          description: address type, Ipv4 or Ipv6
-      required:
-        - addressType
+      oneOf:
+        - $ref: '#/components/schemas/Ipv4Address'
+        - $ref: '#/components/schemas/Ipv6Address'
       discriminator:
         propertyName: addressType
         mapping:
           Ipv4Addr: '#/components/schemas/Ipv4Address'
           Ipv6Addr: '#/components/schemas/Ipv6Address'
     Ipv4Address:
+      type: object
       description: Ipv4 address details
-      allOf:
-        - $ref: '#/components/schemas/IpAddress'
-        - type: object
-          required:
-            - address
-          properties:
-            address:
-              type: string
-              format: ipv4
+      required:
+        - addressType
+        - address
+      properties:
+        addressType:
+          type: string
+          description: address type, Ipv4 or Ipv6
+        address:
+          type: string
+          format: ipv4
     Ipv6Address:
+      type: object
       description: Ipv6 address details
-      allOf:
-        - $ref: '#/components/schemas/IpAddress'
-        - type: object
-          required:
-            - address
-          properties:
-            address:
-              type: string
-              format: ipv6
+      required:
+        - addressType
+        - address
+      properties:
+        addressType:
+          type: string
+          description: address type, Ipv4 or Ipv6
+        address:
+          type: string
+          format: ipv6
     Network:
       description: Base Network Entity structure
       type: object

--- a/code/API_definitions/multi-point-vpn.yaml
+++ b/code/API_definitions/multi-point-vpn.yaml
@@ -345,7 +345,7 @@ components:
           description: connection location
     IpAddress:
       type: object
-      description: Ip address details      
+      description: Ip address details
       properties:
         addressType:
           type: string
@@ -355,10 +355,8 @@ components:
       discriminator:
         propertyName: addressType
         mapping:
-          Ipv4Addr: 
-            $ref: '#/components/schemas/Ipv4Address'
-          Ipv6Addr:
-            $ref: '#/components/schemas/Ipv6Address'
+          Ipv4Addr: '#/components/schemas/Ipv4Address'
+          Ipv6Addr: '#/components/schemas/Ipv6Address'
     Ipv4Address:
       description: Ipv4 address details
       allOf:
@@ -521,7 +519,7 @@ components:
       summary: Create Connection Sampl 1
       description: Create Connection response sample
       value:
-        serviceId: 111111
+        serviceId: '111111'
         connections:
           - customerEdge:
               type: site

--- a/code/Test_definitions/multi-point-vpn.feature
+++ b/code/Test_definitions/multi-point-vpn.feature
@@ -1,0 +1,99 @@
+Feature: CAMARA MultiPoint VPN API
+
+  Background:
+    Given an environment with CAMARA MultiPoint VPN API
+    And the request headers contain a valid access token with the required scope
+
+  # createNetwork - POST /network
+
+  @createNetwork_01_success
+  Scenario: Successfully create a multipoint VPN
+    Given a valid NetworkCreate request body with serviceName, isProtected, connections, guaranteeBandwidth, sla, and duration
+    When I send a POST request to "/network"
+    Then the response status code is 201
+    And the response body includes serviceId, connections, resourceGroupId, and cloudGatewayIP
+
+  @createNetwork_02_invalid_argument
+  Scenario: Create VPN with missing required fields
+    Given a NetworkCreate request body with missing connections
+    When I send a POST request to "/network"
+    Then the response status code is 400
+    And the response property "$.code" is "INVALID_ARGUMENT"
+
+  @createNetwork_03_unauthorized
+  Scenario: Create VPN without authentication
+    Given the request does not include an access token
+    When I send a POST request to "/network"
+    Then the response status code is 401
+    And the response property "$.code" is "UNAUTHENTICATED"
+
+  # getVpnConnection - GET /network/{serviceId}
+
+  @getVpnConnection_01_success
+  Scenario: Successfully retrieve a multipoint VPN
+    Given an existing VPN with a known serviceId
+    When I send a GET request to "/network/{serviceId}"
+    Then the response status code is 200
+    And the response body includes serviceId, connections, sla, and guaranteeBandwidth
+
+  @getVpnConnection_02_not_found
+  Scenario: Retrieve a non-existent VPN
+    Given a serviceId that does not exist
+    When I send a GET request to "/network/{serviceId}"
+    Then the response status code is 404
+
+  # updateNetwork - PATCH /network/{serviceId}
+
+  @updateNetwork_01_success
+  Scenario: Successfully update a multipoint VPN
+    Given an existing VPN with a known serviceId
+    And a valid NetworkUpdate request body with guaranteeBandwidth and sla
+    When I send a PATCH request to "/network/{serviceId}"
+    Then the response status code is 200
+    And the response body reflects the updated guaranteeBandwidth and sla
+
+  @updateNetwork_02_invalid_argument
+  Scenario: Update VPN with out-of-range bandwidth
+    Given an existing VPN with a known serviceId
+    And a NetworkUpdate request body with guaranteeBandwidth of 0
+    When I send a PATCH request to "/network/{serviceId}"
+    Then the response status code is 400
+    And the response property "$.code" is "INVALID_ARGUMENT"
+
+  # deleteNetwork - DELETE /network/{serviceId}
+
+  @deleteNetwork_01_success
+  Scenario: Successfully delete a multipoint VPN
+    Given an existing VPN with a known serviceId
+    When I send a DELETE request to "/network/{serviceId}"
+    Then the response status code is 202
+
+  @deleteNetwork_02_unauthorized
+  Scenario: Delete VPN without authentication
+    Given the request does not include an access token
+    When I send a DELETE request to "/network/{serviceId}"
+    Then the response status code is 401
+    And the response property "$.code" is "UNAUTHENTICATED"
+
+  # assessConnectionFeasibility - POST /assessment
+
+  @assessConnectionFeasibility_01_success
+  Scenario: Successfully assess VPN connection feasibility
+    Given a valid AssessmentRequest body with isProtected, connections, guaranteeBandwidth, and duration
+    When I send a POST request to "/assessment"
+    Then the response status code is 200
+    And the response body includes waitdays, sla, and rent
+
+  @assessConnectionFeasibility_02_invalid_argument
+  Scenario: Assess feasibility with invalid SLA bandwidth
+    Given an AssessmentRequest body with guaranteeBandwidth of 0
+    When I send a POST request to "/assessment"
+    Then the response status code is 400
+    And the response property "$.code" is "INVALID_ARGUMENT"
+
+  @assessConnectionFeasibility_03_unauthorized
+  Scenario: Assess feasibility without authentication
+    Given the request does not include an access token
+    When I send a POST request to "/assessment"
+    Then the response status code is 401
+    And the response property "$.code" is "UNAUTHENTICATED"

--- a/code/Test_definitions/multi-point-vpn.feature
+++ b/code/Test_definitions/multi-point-vpn.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA MultiPoint VPN API
+Feature: CAMARA MultiPoint VPN API vwip
 
   Background:
     Given an environment with CAMARA MultiPoint VPN API


### PR DESCRIPTION
Remove placeholder README.MD and update multi-point-vpn.yaml: change schema references from Connection to Network, rename operationId getVPNConnect to getVpnConnection, add descriptive text for multiple schemas/properties (IpAddress, Ipv4Address, Ipv6Address, Connection/Network groups, SLA, routeProtocal, resourceGroupId, cloudGatewayIP, etc.), fix discriminator mapping format (mapping -> mapping with $ref entries), and add/clarify array and property descriptions. These changes improve schema clarity and correct reference/operation naming.

#### What type of PR is this?

Add one of the following kinds:

correction


#### What this PR does / why we need it:

cleanup before alpha release


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #

#### Special notes for reviewers:

Please review it once

#### Changelog input

```
 release-note

```

#### Additional documentation 

This section can be blank.



```
docs

```
